### PR TITLE
fix: add Traefik network label

### DIFF
--- a/ext-network.yml
+++ b/ext-network.yml
@@ -5,6 +5,7 @@ services:
       - ext-network
     labels:
       - traefik.enable=true
+      - traefik.docker.network=${DOCKER_EXT_NETWORK:-traefik_default}
       - traefik.http.routers.${RPC_HOST:-ronin}.service=${RPC_HOST:-ronin}
       - traefik.http.routers.${RPC_HOST:-ronin}.entrypoints=websecure
       - traefik.http.routers.${RPC_HOST:-ronin}.rule=Host(`${RPC_HOST:-ronin}.${DOMAIN}`)


### PR DESCRIPTION
## Summary
- add traefik.docker.network to the Ronin external network labels so Traefik routes to traefik_default instead of the private compose network